### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
-/usr/libexec/tangd-keygen /var/db/tang
-/usr/libexec/tangd-update /var/db/tang /var/cache/tang
-
+val=$(ls -A /var/db/tang/*.jwk 2>/dev/null | wc -l)
+if [ $val -eq 0 ]
+then
+	echo "Generating new tang keys..."
+	/usr/libexec/tangd-keygen /var/db/tang
+	/usr/libexec/tangd-update /var/db/tang /var/cache/tang
+else
+	echo "Reusing existing tang keys in /var/db/tang"
+fi
 exec "$@"
+


### PR DESCRIPTION
Check to see if keys already exist and prevent regeneration of new keys each time same container is started. This is needed for use with reusable volumes / containers.